### PR TITLE
FACES-2686 compat 2x

### DIFF
--- a/portal/src/main/java/com/liferay/faces/portal/render/internal/PortalTagRenderer.java
+++ b/portal/src/main/java/com/liferay/faces/portal/render/internal/PortalTagRenderer.java
@@ -46,7 +46,7 @@ import com.liferay.taglib.aui.ScriptTag;
  *
  * @author  Neil Griffin
  */
-public abstract class PortalTagRenderer<U extends UIComponent, T extends Tag> extends Renderer {
+public abstract class PortalTagRenderer<U extends UIComponent, T extends Tag> extends PortalTagRendererCompat {
 
 	// Protected Constants
 	protected static final String CORRESPONDING_JSP_TAG = "correspondingJspTag";
@@ -146,10 +146,6 @@ public abstract class PortalTagRenderer<U extends UIComponent, T extends Tag> ex
 
 	public String getChildInsertionMarker() {
 		return null;
-	}
-
-	protected HttpServletRequest getHttpServletRequest(PortletRequest portletRequest) {
-		return new HttpServletRequestTagSafeImpl(PortalUtil.getHttpServletRequest(portletRequest));
 	}
 
 	protected HttpServletResponse getHttpServletResponse(PortletResponse portletResponse) {

--- a/portal/src/main/java/com/liferay/faces/portal/render/internal/PortalTagRendererCompat.java
+++ b/portal/src/main/java/com/liferay/faces/portal/render/internal/PortalTagRendererCompat.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-2016 Liferay, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.liferay.faces.portal.render.internal;
+
+import javax.faces.render.Renderer;
+import javax.portlet.PortletRequest;
+import javax.servlet.http.HttpServletRequest;
+
+import com.liferay.portal.kernel.util.PortalUtil;
+
+
+/**
+ * This abstract class provides a compatibility layer for different versions of Liferay
+ *
+ * @author  Juan Gonzalez
+ */
+public abstract class PortalTagRendererCompat extends Renderer {
+
+	protected HttpServletRequest getHttpServletRequest(PortletRequest portletRequest) {
+		return new HttpServletRequestTagSafeImpl(PortalUtil.getOriginalServletRequest(
+					PortalUtil.getHttpServletRequest(portletRequest)));
+	}
+}

--- a/portal/src/main/java/com/liferay/faces/portal/render/internal/PortalTagRendererCompat.java
+++ b/portal/src/main/java/com/liferay/faces/portal/render/internal/PortalTagRendererCompat.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.util.PortalUtil;
 public abstract class PortalTagRendererCompat extends Renderer {
 
 	protected HttpServletRequest getHttpServletRequest(PortletRequest portletRequest) {
-		return new HttpServletRequestTagSafeImpl(PortalUtil.getOriginalServletRequest(
-					PortalUtil.getHttpServletRequest(portletRequest)));
+		return new HttpServletRequestTagSafeImpl(PortalUtil.getHttpServletRequest(portletRequest));
 	}
 }


### PR DESCRIPTION
Hi @ngriffin7a. In the end I added the compatibility later for previous versions, as we need to override anyway.

I kept the previous behavior for Liferay 6.x versions.

Please backport to 1.x if feasible.

Thanks!
