### PR TITLE
FACES-3158 Component documentation incorrectly lists required, immediate, and readonly attributes as type java.lang.Boolean instead of boolean

### DIFF
--- a/portal/pom.xml
+++ b/portal/pom.xml
@@ -204,7 +204,7 @@
 							<dependency>
 								<groupId>com.liferay.faces</groupId>
 								<artifactId>com.liferay.faces.generator</artifactId>
-								<version>1.0.1</version>
+								<version>1.1.1</version>
 							</dependency>
 						</dependencies>
 					</plugin>

--- a/portal/src/main/resources/META-INF/portal.taglib.xml
+++ b/portal/src/main/resources/META-INF/portal.taglib.xml
@@ -52,7 +52,7 @@
 			<description><![CDATA[When this flag is true, this component's value must be converted and validated (immediately) during the Apply Request Values phase, instead of (later) during the PROCESS_VALIDATIONS phase.]]></description>
 			<name>immediate</name>
 			<required>false</required>
-			<type>java.lang.Boolean</type>
+			<type>boolean</type>
 		</attribute>
 		<attribute>
 			<description><![CDATA[A localized label for this component that is typically only rendered in a FacesMessage when validation fails.]]></description>
@@ -239,7 +239,7 @@ java.lang.Object)</method-signature>
 			<description><![CDATA[When this flag is true, this component's value must be converted and validated (immediately) during the Apply Request Values phase, instead of (later) during the PROCESS_VALIDATIONS phase.]]></description>
 			<name>immediate</name>
 			<required>false</required>
-			<type>java.lang.Boolean</type>
+			<type>boolean</type>
 		</attribute>
 		<attribute>
 			<description><![CDATA[A localized label for this component that is typically only rendered in a FacesMessage when validation fails.]]></description>
@@ -287,7 +287,7 @@ java.lang.Object)</method-signature>
 			<description><![CDATA[When this flag is true, and a value has not been specified for this component, then the PROCESS_VALIDATIONS phase will fail and a FacesMessage will be added to the FacesContext for this component.]]></description>
 			<name>required</name>
 			<required>false</required>
-			<type>java.lang.Boolean</type>
+			<type>boolean</type>
 		</attribute>
 		<attribute>
 			<description><![CDATA[This message or the result of the specified expression, will be used as the text of the validation error message instead of any message that comes from the resulting validation error for this component when required="true" and no value is selected by the user.]]></description>


### PR DESCRIPTION
@ngriffin7a please merge and backport back to and including `3.x`.