### PR TITLE
FACES-XXXX The demo usage of local services usage can result in a NullPointerException if the service is stopped after the isEmpty check

### DIFF
--- a/demo/primefaces-users-portlet/src/main/java/com/liferay/faces/demos/bean/TestSetupBackingBean.java
+++ b/demo/primefaces-users-portlet/src/main/java/com/liferay/faces/demos/bean/TestSetupBackingBean.java
@@ -90,13 +90,12 @@ public class TestSetupBackingBean {
 		long[] userGroupIds = new long[] {};
 		boolean sendEmail = false;
 		ServiceContext serviceContext = new ServiceContext();
-		UserLocalService userLocalService;
+		UserLocalService userLocalService = userLocalServiceTracker.getService();
 
-		if (userLocalServiceTracker.isEmpty()) {
+		if (userLocalService == null) {
 			FacesContextHelperUtil.addGlobalErrorMessage("is-temporarily-unavailable", "User service");
 		}
 		else {
-			userLocalService = userLocalServiceTracker.getService();
 
 			boolean addUser = false;
 
@@ -166,10 +165,9 @@ public class TestSetupBackingBean {
 	public void resetUsers(ActionEvent actionEvent) throws PortalException {
 
 		FacesContext facesContext = FacesContext.getCurrentInstance();
+		CompanyLocalService companyLocalService = companyLocalServiceTracker.getService();
 
-		if (!companyLocalServiceTracker.isEmpty()) {
-
-			CompanyLocalService companyLocalService = companyLocalServiceTracker.getService();
+		if (companyLocalService != null) {
 
 			try {
 				long companyId = LiferayPortletHelperUtil.getCompanyId(facesContext);

--- a/demo/primefaces-users-portlet/src/main/java/com/liferay/faces/demos/bean/UsersBackingBean.java
+++ b/demo/primefaces-users-portlet/src/main/java/com/liferay/faces/demos/bean/UsersBackingBean.java
@@ -120,10 +120,9 @@ public class UsersBackingBean {
 	public void save(ActionEvent actionEvent) {
 
 		try {
+			UserLocalService userLocalService = userLocalServiceTracker.getService();
 
-			if (!userLocalServiceTracker.isEmpty()) {
-
-				UserLocalService userLocalService = userLocalServiceTracker.getService();
+			if (userLocalService != null) {
 
 				// Update the selected user in the Liferay database.
 				User user = usersModelBean.getSelectedUser();

--- a/demo/primefaces-users-portlet/src/main/java/com/liferay/faces/demos/bean/UsersModelBean.java
+++ b/demo/primefaces-users-portlet/src/main/java/com/liferay/faces/demos/bean/UsersModelBean.java
@@ -87,10 +87,10 @@ public class UsersModelBean implements Serializable {
 			FacesContext facesContext = FacesContext.getCurrentInstance();
 			int rowsPerPage = PortletHelperUtil.getPortletPreferenceAsInt(facesContext, "rowsPerPage",
 					SearchContainer.DEFAULT_DELTA);
+			UserLocalService userLocalService = userLocalServiceTracker.getService();
 
-			if (!userLocalServiceTracker.isEmpty()) {
+			if (userLocalService != null) {
 
-				UserLocalService userLocalService = userLocalServiceTracker.getService();
 				userDataModel = new UserLazyDataModel(userLocalService,
 						LiferayPortletHelperUtil.getCompanyId(facesContext), rowsPerPage);
 			}

--- a/demo/primefaces-users-portlet/src/main/java/com/liferay/faces/demos/resource/UserPortraitResourceHandler.java
+++ b/demo/primefaces-users-portlet/src/main/java/com/liferay/faces/demos/resource/UserPortraitResourceHandler.java
@@ -92,8 +92,9 @@ public class UserPortraitResourceHandler extends ResourceHandlerWrapper {
 					UserLocalServiceTracker userLocalServiceTracker = new UserLocalServiceTracker(bundleContext);
 					userLocalServiceTracker.open();
 
-					if (!userLocalServiceTracker.isEmpty()) {
-						UserLocalService userLocalService = userLocalServiceTracker.getService();
+					UserLocalService userLocalService = userLocalServiceTracker.getService();
+
+					if (userLocalService != null) {
 						user = userLocalService.getUser(Long.parseLong(userId));
 					}
 					else {


### PR DESCRIPTION
OSGi services may be stopped or uninstalled at any time. The demo pattern for using services is:

```
if (!someLocalServiceTracker.isEmpty()) {
    SomeLocalService someLocalService = someLocalServiceTracker.getService();
    someLocalService.callMethod();
} else {
    FacesContextHelperUtil.addGlobalErrorMessage("is-temporarily-unavailable", "Some service");
}
```

This pattern is susceptible to a `NullPointerException` if the service is removed after the call to `someLocalServiceTracker.isEmpty()` and before the call to `someLocalServiceTracker.getService()`.

Instead the code should get the service and check for null.

Unfortunately I'm unable to create a ticket because I don't have access to the Liferay Jira.