### PR TITLE
LPD-16638 Expando throws NoSuchColumnException

### DIFF
--- a/demo/jsf-registration-portlet/src/main/java/com/liferay/faces/demos/hook/RegisterExpandoAction.java
+++ b/demo/jsf-registration-portlet/src/main/java/com/liferay/faces/demos/hook/RegisterExpandoAction.java
@@ -75,9 +75,14 @@ public class RegisterExpandoAction extends SimpleAction {
 			logger.debug("Added expando table for modelClassName=[{0}]", modelClassName);
 		}
 
-		ExpandoColumn expandoColumn;
+		ExpandoColumn expandoColumn = null;
 
-		expandoColumn = ExpandoColumnLocalServiceUtil.getColumn(expandoTable.getTableId(), expandoColumnName);
+		try {
+			expandoColumn = ExpandoColumnLocalServiceUtil.getColumn(expandoTable.getTableId(), expandoColumnName);
+		} catch (Exception e) {
+			logger.debug("No column found with name: " + expandoColumnName + " in ExpandoTable id: " +
+					expandoTable.getTableId());
+		}
 
 		if (expandoColumn != null) {
 			logger.debug("Expando column=[{0}] exists for modelClassName=[{1}]", expandoColumnName, modelClassName);


### PR DESCRIPTION
@ngriffin7a Hi Neil,
This is Julius from Core. Recently there was a Liferay Faces functional test that failed see here: https://liferay.atlassian.net/browse/LPD-16638

After investigation, we think there are two things that are causing it:
1. ExpandoColumnLocalServiceUtil getColumn method impl now throws NoSuchColumnException (it showed up in the functional test)  See ref: https://liferay.atlassian.net/browse/LPD-12631, https://github.com/liferay/liferay-portal/commit/23da8740                ----> this PR just catch the exception so that's like the old behavior

2. log4j1.2 is removed from portal. We need to remove log4j1.2 dependency completely. This part I tried to see what I could do but ultimately could not since I'm not very familiar with all the liferay-faces repos. But I see that you have a ticket here for it almost done: https://liferay.atlassian.net/browse/FACES-3698

Could you please help us take lead and finish removing log4j1.2?
This issue is a release blocker and need to take care soon.
https://liferay.atlassian.net/browse/LPD-16638

Thank you! 
